### PR TITLE
Allows Other Components and Extensions to Modify Statement

### DIFF
--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -416,8 +416,9 @@ define(function(require) {
       if (!statement) {
         return;
       }
-
+      Adapt.trigger("xapi:willSendStatement", statement);
       xapiWrapper.sendStatement(statement, callback)
+      Adapt.trigger("xapi:didSendStatement", statement);
     },
 
     getObjectDefinition: function() {


### PR DESCRIPTION
Trigger an event before and after sending a statement to the LRS to allow other plugins the opportunity to modify the statement.