### PR TITLE
Allows XAPI to Listen and Track to Content Object

### DIFF
--- a/js/adapt-xapi.js
+++ b/js/adapt-xapi.js
@@ -13,6 +13,7 @@ define(function(require) {
   var xapi = require('./xapiwrapper.min');
   var AssessmentStatementModel = require('./models/assessment-statement');
   var ComponentStatementModel = require('./models/component-statement');
+  var ContentObjectStatementModel = require('./models/content-object-statement');
 
   var xapiWrapper;
   var STATE_PROGRESS = 'adapt-course-progress';
@@ -73,6 +74,7 @@ define(function(require) {
     },
 
     setupListeners: function() {
+      this.listenTo(Adapt.contentObjects, "change:_isComplete", this.onContentObjectsComplete);
       this.listenTo(Adapt.components, "change:_isComplete", this.onComponentComplete);
       this.listenTo(Adapt.blocks, "change:_isComplete", this.onBlockComplete);
       this.listenTo(Adapt.course, "change:_isComplete", this.onCourseComplete);
@@ -126,6 +128,29 @@ define(function(require) {
 
         Adapt.trigger('xapi:stateChanged');
       }
+    },
+
+    onContentObjectsComplete: function(contentObject) {
+      if (contentObject.get('_recordInteraction') !== true) {
+        return;
+      }
+
+      var statementModel = new ContentObjectStatementModel({
+        activityId: this.get('activityId'),
+        actor: this.get('actor'),
+        registration: this.get('registration'),
+        model: contentObject
+      });
+
+      if (!statementModel) {
+        return;
+      }
+
+      var statement = statementModel.getStatementObject();
+
+      this.sendStatement(
+        statement
+      );
     },
 
     onCourseComplete: function() {

--- a/js/models/content-object-statement.js
+++ b/js/models/content-object-statement.js
@@ -1,0 +1,84 @@
+define(function(require) {
+
+  var Adapt = require('coreJS/adapt');
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var StatementModel = require('./statement');
+
+  var ContentObjectStatementModel = StatementModel.extend({
+
+    initialize: function() {
+      return StatementModel.prototype.initialize.call(this);
+    },
+
+    getStatementObject: function() {
+      var statement = StatementModel.prototype.getStatementObject.call(this);
+
+      var verb = this.getVerb();
+      var object = this.getObject();
+      var context = this.getContext();
+
+      if (
+        _.isEmpty(verb) ||
+        _.isEmpty(object) ||
+        _.isEmpty(context)
+      ) {
+        return null;
+      }
+
+      statement.verb = verb;
+      statement.object = object;
+      statement.context = context;
+
+      return statement;
+    },
+
+    getVerb: function() {
+      return StatementModel.prototype.getVerb.call(this);
+    },
+
+    getObject: function() {
+      return StatementModel.prototype.getObject.call(this);
+    },
+
+    getActivityDefinitionObject: function() {
+      var object = StatementModel.prototype.getActivityDefinitionObject.call(this);
+
+      if (_.isEmpty(object)) {
+        object = {};
+      }
+
+      object.name = {};
+      object.name[Adapt.config.get('_defaultLanguage')] = this.get('model').get('title');
+
+      object.type = ['http://adaptlearning.org', this.get('model').get('_type'), this.get('model').get('_id')].join('/');
+
+      return object;
+    },
+
+    getIri: function() {
+      if (
+        _.isEmpty(this.get('activityId')) ||
+        _.isEmpty(this.get('model')) ||
+        _.isEmpty(this.get('model').get('_type')) ||
+        _.isEmpty(this.get('model').get('_id'))
+      ) {
+        return null;
+      }
+
+      return [this.get('activityId'), this.get('model').get('_type'), this.get('model').get('_id')].join('/');
+    },
+
+    getContext: function() {
+      return StatementModel.prototype.getContext.call(this);
+    },
+
+    getContextActivities: function() {
+      return StatementModel.prototype.getContextActivities.call(this);
+    },
+
+  });
+
+  return ContentObjectStatementModel;
+
+});

--- a/properties.schema
+++ b/properties.schema
@@ -76,7 +76,18 @@
           "type":"object"
         },
         "contentobject": {
-          "type":"object"
+          "type":"object",
+          "properties": {
+            "_recordInteraction": {
+              "type":"boolean",
+              "required":true,
+              "default": false,
+              "title":"Record interaction",
+              "inputType": {"type": "Boolean", "options": [true, false]},
+              "validators": [],
+              "help": "Allows individual content objects to trigger completion"
+            },
+          }
         },
         "article": {
           "type":"object"


### PR DESCRIPTION
Allow statements to optionally be reported for any contentObject. This is be configurable via the Adapt Authoring tool.