### PR TITLE
Adjusts XAPI Activity ID To Point To Assessment IRI

### DIFF
--- a/js/models/assessment-statement.js
+++ b/js/models/assessment-statement.js
@@ -110,6 +110,10 @@ define(function(require) {
         return null;
       }
 
+      if(Adapt.config.get("_xapi")._tracking._activityIdForIri===true) {
+        return [this.get('activityId'), '#', 'id', this.get('model').pageId].join('/');
+      }
+      
       return [this.get('activityId'), 'assessment', this.get('model').id].join('/');
     },
 

--- a/properties.schema
+++ b/properties.schema
@@ -65,7 +65,16 @@
                       "inputType": {"type": "Boolean", "options": [true, false]},
                       "validators": [],
                       "help": ""
-                    }
+                    },
+                    "_activityIdForIri": {
+                      "type":"boolean",
+                      "required":false,
+                      "default": false,
+                      "title":"Based IRI on the course’s activity ID",
+                      "inputType": {"type": "Boolean", "options": [true, false]},
+                      "validators": [],
+                      "help": "Allow for completion statements to optionally be reported for any contentObject"
+                    }            
                   }
                 }
               }


### PR DESCRIPTION
Modify the activity ID reported with assessments to be a valid IRI to the assessment (based on the course’s activity ID). This adjusts “assessment/assessment-id” with “#/id/content-id” so it directly reflects Adapt's URL structure.