### PR TITLE
Fixes error identifier collision in getState

### DIFF
--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -929,8 +929,8 @@ define([
             var parseError;
             try {
               response = JSON.parse(xhr.response);
-            } catch (error) {
-              parseError = error;
+            } catch (e) {
+              parseError = e;
             }
 
             if (parseError) {


### PR DESCRIPTION
`error` is already defined in this scope which causes the uglifier (when building the Adapt course) to incorrectly mangle the variables in this function leading to a JavaScript error when restoring state.

FWIW, here's a screenshot of the final course output before this fix is applied.
<img width="986" alt="uglified" src="https://user-images.githubusercontent.com/480718/38774710-c15b688a-4034-11e8-9c4e-db50f67c19cd.png">
The callback error parameter is mangled as `n`, but the callback function checks for the existence of an `l` variable, which doesn't exist, causing an execution error.