### PR TITLE
Adds support for a blacklist of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Some setup is required in order to configure the xAPI extension.  If using a sta
 |Verb language | `en-US`| Indicates the language of the verbs which will be passed to the LRS
 |Auto generate IDs for statements | `false` | It is recommended this is not enabled, so that the LRS will generate unique identifiers
 |Track state| `false` | Lets the LRS manage the course state via the State API
-|LRS connection failur behaviour | Show errors | Indicates what should happen when the course cannot connect to the LRS
-
+|LRS connection failure behaviour | Show errors | Indicates what should happen when the course cannot connect to the LRS
+|Component blacklist | `blank,graphic` | A comma-separated list of components which should not send statements.  Set this to an empty string if all components should send a statement.
+ 
 By default the xAPI extension listens for the following *core* events.  Those without an asterisk (*) can be toggled via configuration:
 
 | Object |Event  |

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-xapi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-xapi",
   "authors": [
     "Dennis Heaney <dennis@learningpool.com>",

--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -97,15 +97,16 @@ define([
           lang: this.getConfig('_lang'),
           generateIds: this.getConfig('_generateIds'),
           shouldTrackState: this.getConfig('_shouldTrackState'),
-          componentBlacklist: this.getConfig('_componentBlacklist') || ''
+          componentBlacklist: this.getConfig('_componentBlacklist') || []
         });
 
         var componentBlacklist = this.get('componentBlacklist');
 
-        if (!componentBlacklist) {
-          componentBlacklist = [];
-        } else {
-          componentBlacklist = componentBlacklist.split(',');
+        if (!_.isArray(componentBlacklist)) {
+          // Create the blacklist array and force the items to lowercase.
+          componentBlacklist = componentBlacklist.split(/,\s?/).map(function(component) {
+            return component.toLowerCase();
+          });
         }
 
         this.set('componentBlacklist', componentBlacklist);
@@ -527,7 +528,7 @@ define([
         return;
       }
 
-      if (this.get('componentBlacklist').indexOf(view.model.get('_component')) !== -1) {
+      if (this.isComponentOnBlacklist(view.model.get('_component'))) {
         // This component is on the blacklist, so do not send a statement.
         return;
       }
@@ -635,6 +636,15 @@ define([
     },
 
     /**
+     * Checks if a given component is blacklisted from sending statements.
+     * @param {string} component - The name of the component.
+     * @returns {boolean} true if the component exists on the blacklist.
+     */
+    isComponentOnBlacklist: function(component) {
+      return this.get('componentBlacklist').indexOf(component) !== -1;
+    },
+
+    /**
      * Sends an xAPI statement when an item has been completed.
      * @param {AdaptModel} model - An instance of AdaptModel, i.e. ComponentModel, BlockModel, etc.
      */
@@ -647,7 +657,7 @@ define([
         return;
       }
 
-      if (model.get('_type') === 'component' && this.get('componentBlacklist').indexOf(model.get('_component')) !== -1) {
+      if (model.get('_type') === 'component' && this.isComponentOnBlacklist(model.get('_component'))) {
         // This component is on the blacklist, so do not send a statement.
         return;
       }

--- a/properties.schema
+++ b/properties.schema
@@ -74,7 +74,7 @@
                     ]
                   },
                   "validators": [],
-                  "help": "Indicates whether the plugin should use standard xAPI or (comming soon) cmi5 profile"
+                  "help": "Indicates whether the plugin should use standard xAPI or cmi5 profile (comming soon)."
                 },
                 "_activityID": {
                   "type": "string",
@@ -152,6 +152,15 @@
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "When enabled, the associated LRS be used to track state via the State API."
+                },
+                "_componentBlacklist": {
+                  "type": "string",
+                  "required": false,
+                  "default": "blank,graphic",
+                  "title": "Component blacklist",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "Comma separated list of components which will not send statements."
                 },
                 "_coreEvents": {
                   "type": "object",


### PR DESCRIPTION
Initial testing reported that it isn't that useful to send a statement for all component interactions.

As such, the graphic and blank component have been added by default to a list which will not send statements.