### PR TITLE
Fixes #20 Tighten up sending of suspended/terminated statements - 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-xapi",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "framework": ">=3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-xapi",
   "authors": [

--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -1298,6 +1298,7 @@ define([
         cache: 'no-cache',
         credentials: credentials,
         headers: headers,
+        mode: 'same-origin',
         keepalive: true,
         method: 'POST'
       }).then(function() {
@@ -1314,7 +1315,7 @@ define([
      */
     isCORS: function(url) {
       var urlparts = url.toLowerCase().match(/^(.+):\/\/([^:\/]*):?(\d+)?(\/.*)?$/);
-      var isCORS = (location.protocol.toLowerCase() !== urlparts[1] || location.hostname.toLowerCase() !== urlparts[2]);
+      var isCORS = (location.protocol.toLowerCase().replace(':', '') !== urlparts[1] || location.hostname.toLowerCase() !== urlparts[2]);
       if (!isCORS) {
         var urlPort = (urlparts[3] === null ? (urlparts[1] === 'http' ? '80' : '443') : urlparts[3]);
         isCORS = (urlPort === location.port);

--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -127,11 +127,11 @@ define([
         this.courseName = Adapt.course.get('displayTitle') || Adapt.course.get('title');
         this.courseDescription = Adapt.course.get('description') || '';
 
-        var statements = [];
-
         // Send the 'launched' and 'initialized' statements.
-        statements.push(this.getCourseStatement(ADL.verbs.launched));
-        statements.push(this.getCourseStatement(ADL.verbs.initialized));
+        var statements = [
+          this.getCourseStatement(ADL.verbs.launched),
+          this.getCourseStatement(ADL.verbs.initialized)
+        ];
 
         this.sendStatements(statements, _.bind(function(error) {
           if (error) {

--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -278,6 +278,8 @@ define([
      */
     onVisibilityChange: function() {
       if (document.visibilityState === 'visible') {
+        this.isTerminated = false;
+
         return this.sendStatement(this.getCourseStatement(ADL.verbs.resumed));
       }
 
@@ -286,6 +288,10 @@ define([
 
     // Sends (optional) 'suspended' and 'terminated' statements to the LRS.
     sendUnloadStatements: function() {
+      if (this.isTerminated) {
+        return;
+      }
+
       var statements = [];
 
       if (!this.isComplete) {


### PR DESCRIPTION
- Use visibilitychange for devices as unload events aren't supported
- Use the fetch API with keepalive flag where possible
- Fallback to AJAX for CORS as custom headers not supported in preflight