### PR TITLE
added registration to sendState and getState calls

### DIFF
--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -949,6 +949,7 @@ define([
       var activityId = this.get('activityId');
       var actor = this.get('actor');
       var type = model.get('_type');
+      var registration = this.get('registration');
       var state = this.get('state');
       var collectionName = _.findKey(this.coreObjects, function(o) {
         return o === type || o.indexOf(type) > -1
@@ -977,7 +978,7 @@ define([
       });
 
       // Pass the new state to the LRS.
-      this.xapiWrapper.sendState(activityId, actor, collectionName, null, newState, null, null, function(error, xhr) {
+      this.xapiWrapper.sendState(activityId, actor, collectionName, registration, newState, null, null, function(error, xhr) {
         if (error) {
           Adapt.trigger('xapi:lrs:sendState:error', error);
         }
@@ -996,10 +997,11 @@ define([
       var self = this;
       var activityId = this.get('activityId');
       var actor = this.get('actor');
+      var registration = this.get('registration');
       var state = {};
 
       Async.each(_.keys(this.coreObjects), function(type, nextType) {
-        self.xapiWrapper.getState(activityId, actor, type, null, null, function(error, xhr) {
+        self.xapiWrapper.getState(activityId, actor, type, registration, null, function(error, xhr) {
           _.defer(function() {
             if (error) {
               Adapt.log.warn('adapt-contrib-xapi: getState() failed for ' + activityId + ' (' + type + ')');


### PR DESCRIPTION
Without the registration value being recorded in our state objects, our system was returning state from previous attempts. This change fixes that issue.