### PR TITLE
Resolves #70, changes order of ActivityId detection

### DIFF
--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -97,7 +97,7 @@ define([
         }
 
         this.set({
-          activityId: (this.getConfig('_activityID') || this.getLRSAttribute('activity_id') || this.getBaseUrl()),
+          activityId: (this.getLRSAttribute('activity_id') || this.getConfig('_activityID') || this.getBaseUrl()),
           displayLang: Adapt.config.get('_defaultLanguage'),
           lang: this.getConfig('_lang'),
           generateIds: this.getConfig('_generateIds'),


### PR DESCRIPTION
The order of the checks is now:
1. 'activity_id' querystring parameter in the URL
2. '_activityID' defined in config.json

If neither is found, a fallback to use the current URL.