### PR TITLE
Resolves #77, adds support for storing 'assessment-id' as an extension

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-xapi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "framework": ">=3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-xapi",
   "authors": [

--- a/js/adapt-contrib-xapi.js
+++ b/js/adapt-contrib-xapi.js
@@ -2,7 +2,6 @@
  * adapt-contrib-xapi
  * License      - http://github.com/adaptlearning/adapt_framework/LICENSE
  * Maintainers  - Dennis Heaney <dennis@learningpool.com>
- *              - Barry McKay <barry@learningpool.com>
  *              - Brian Quinn <brian@learningpool.com>
  */
 define([
@@ -831,6 +830,12 @@ define([
           }
 
           statement.addParentActivity(this.getAssessmentObject(assessment))
+
+          if (assessment.id) {
+            statement.object.definition.extensions = _.extend({}, statement.object.definition.extensions, {
+              'http://id.tincanapi.com/extension/assessment-id': assessment.id
+            });
+          }
         }
       }
     },
@@ -902,6 +907,12 @@ define([
 
       statement.addGroupingActivity(this.getCourseActivity())
       statement.addGroupingActivity(this.getLessonActivity(assessment.pageId))
+
+      if (assessment.id) {
+        statement.object.definition.extensions = _.extend({}, statement.object.definition.extensions, {
+          'http://id.tincanapi.com/extension/assessment-id': assessment.id
+        });
+      }
 
       // Delay so that component completion can be recorded before assessment completion.
       _.delay(function() {


### PR DESCRIPTION
I'm not going to merge this until 'assessment-id' gets added to the TinCan registry.  