### PR TITLE
Resolves #98, ensures 'registration' is set for ADL launched get/set state calls

### DIFF
--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -216,7 +216,8 @@ class XAPI extends Backbone.Model {
           this.xapiWrapper = xapiWrapper;
 
           this.set({
-            actor: launchData.actor
+            actor: launchData.actor,
+            registration: xapiWrapper.lrs.registration
           });
 
           this.xapiWrapper.strictCallbacks = true;


### PR DESCRIPTION
https://github.com/adaptlearning/adapt-contrib-xapi/issues/98