### PR TITLE
issue/97

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-xapi",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "framework": ">=5.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-xapi",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-xapi",
-  "version": "0.9.2",
+  "version": "0.9.1",
   "framework": ">=5.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-xapi",
   "authors": [

--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -65,8 +65,6 @@ class XAPI extends Backbone.Model {
   async initialize() {
     if (!this.getConfig('_isEnabled')) return this;
 
-    this.listenToOnce(Adapt, 'app:dataLoaded', this.onDataLoaded);
-
     Adapt.wait.begin();
 
     // Initialize the xAPIWrapper.
@@ -153,17 +151,6 @@ class XAPI extends Backbone.Model {
     this.restoreState();
     this.onInitialised();
     return this;
-  }
-
-  onDataLoaded() {
-    this.listenTo(Adapt, {
-      'adapt:initialize': this.setupListeners,
-      'xapi:lrs:initialize:error': error => {
-        Adapt.log.error('adapt-contrib-xapi: xAPI Wrapper initialisation failed', error);
-        this.showError();
-      },
-      'xapi:lrs:sendStatement:error xapi:lrs:sendState:error': this.showError
-    });
   }
 
   static getInstance() {
@@ -1508,4 +1495,4 @@ class XAPI extends Backbone.Model {
   }
 }
 
-export default XAPI.getInstance();
+export default XAPI;

--- a/js/setupOfflineStorage.js
+++ b/js/setupOfflineStorage.js
@@ -1,8 +1,7 @@
 import Adapt from 'core/js/adapt';
-import XAPI from './XAPI';
 
 // xAPI handler for Adapt.offlineStorage interface.
-export default function setupOfflineStorage() {
+export default function setupOfflineStorage(XAPI) {
   // Use a lightweight fake model to pass into xAPI.sendState
   const fakeModel = {
     get() {


### PR DESCRIPTION
Preventing early XAPI.initialize call by placing onDataLoaded functionality onto XAPIIndex

Fixes #97 