### PR TITLE
Issues/105 Bugfix termination statements failing

### DIFF
--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -1331,8 +1331,10 @@ class XAPI extends Backbone.Model {
       'X-Experience-API-Version': window.ADL.XAPIWrapper.xapiVersion
     };
 
+    const lrsExtended = lrs.extended || [];
+
     // Add extended LMS-specified values to the URL
-    const extended = lrs.extended.map((value, key) => {
+    const extended = lrsExtended.map((value, key) => {
       return key + '=' + encodeURIComponent(value);
     });
 

--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -1363,7 +1363,7 @@ class XAPI extends Backbone.Model {
    * @returns {boolean}
    */
   isCORS(url) {
-    const urlparts = url.toLowerCase().match(/^(.+):\/\/([^:]*):?(\d+)?(\/.*)?$/);
+    const urlparts = url.toLowerCase().match(/^(.+):\/\/([^:\/]*):?(\d+)?(\/.*)?$/);
     let isCORS = (location.protocol.toLowerCase().replace(':', '') !== urlparts[1] || location.hostname.toLowerCase() !== urlparts[2]);
     if (isCORS) return true;
     const urlPort = (urlparts[3] === null ? (urlparts[1] === 'http' ? '80' : '443') : urlparts[3]);


### PR DESCRIPTION
fixes #105 

Fixed

- isCORS check had an incorrect regex
- mapping attempted on undefined `lrs.extended` value