### PR TITLE
Fix: attachment check covers null as well as undefined

### DIFF
--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -1307,7 +1307,7 @@ class XAPI extends Backbone.Model {
 
     // Allow the trigger above to augment attachments if the attachments
     // parameter is not set.
-    if (attachments === undefined && statement.attachments) {
+    if (!attachments && statement.attachments) {
       return await this.processAttachments(statement);
     }
     await this.onStatementReady(statement, attachments);


### PR DESCRIPTION
Fixes #https://github.com/adaptlearning/adapt-contrib-xapi/issues/115

### Fix
* Check for attachment parameter now correctly handles a null value

### Testing
1. Create a course with xapi extension and a custom plugin that will add an 'attachments' array of objects to the xapi statement.
Attachment objects should be of the form outlined here - https://www.npmjs.com/package/xapiwrapper/v/1.11.0#send-statement-with-attachments



