### PR TITLE
Fix: Using callback approach so attachments param can be included

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -1385,13 +1385,16 @@ class XAPI extends Backbone.Model {
    * @param {array} [attachments] - An array of attachments to pass to the LRS.
    */
   async onStatementReady(statement, attachments) {
-    try {
-      await this.xapiWrapper.sendStatement(statement, attachments);
-    } catch (error) {
-      Adapt.trigger('xapi:lrs:sendStatement:error', error);
-      throw error;
+    const sendStatementCallback = (error, res, body) => {
+      if (error) {
+        Adapt.trigger('xapi:lrs:sendStatement:error', error);
+        throw error;
+      }
+
+      Adapt.trigger('xapi:lrs:sendStatement:success', body);
     }
-    Adapt.trigger('xapi:lrs:sendStatement:success', statement);
+
+    this.xapiWrapper.sendStatement(statement, sendStatementCallback, attachments);
   }
 
   /**


### PR DESCRIPTION
Fixes: #117 

### Fix
* sendStatement calls which include attachments will now work as expected

[//]: # (List appropriate steps for testing if needed)
### Testing
Create a course with xapi extension and a custom plugin that will add an 'attachments' array of objects to the xapi statement.
Attachment objects should be of the form outlined here - https://www.npmjs.com/package/xapiwrapper/v/1.11.0#send-statement-with-attachments
