### PR TITLE
Fix: Test harness html files now load correct resources (fixes #122)

### DIFF
--- a/required/xapi_adl_test_harness.html
+++ b/required/xapi_adl_test_harness.html
@@ -3,31 +3,27 @@
   configuration for this extension for the ADL method to be utilised
 -->
 
-<!--[if IE]><![endif]-->
 <!doctype html>
-<!--[if IE 7 ]><html id="adapt" class="ie ie7 no-js" lang="en"><![endif]-->
-<!--[if IE 8 ]><html id="adapt" class="ie ie8 no-js" lang="en"><![endif]-->
-<!--[if IE 9 ]><html id="adapt" class="ie ie9 no-js" lang="en"><![endif]-->
-<!--[if gt IE 9]><!--><html id="adapt" class="no-js" lang="en"><!--<![endif]-->
-    <head>
-        <script src="libraries/js-cookie.js" type="text/javascript" language="javascript"></script>
-        <script src="libraries/xapiwrapper.min.js" type="text/javascript" language="javascript"></script>
-        <script src="offline_xapi_adl_wrapper.js" type="text/javascript" language="javascript"></script>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-        <meta content="utf-8" http-equiv="encoding">
-        <meta name="apple-mobile-web-app-capable" content="yes"/>
-        <title></title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-        <link href="adapt/css/adapt.css" type="text/css" rel="stylesheet"/>
-        <script src="libraries/modernizr.js" type="text/javascript" language="javascript"></script>
-        <script src="adapt/js/scriptLoader.js" type="text/javascript" language="javascript"></script>
-    </head>
-
-    <body>
-        <button id="accessibility-toggle" class="base button a11y-ignore-focus" role="button" ></button>
-        <span id="accessibility-instructions" class="aria-label" role="region" tabindex="0"></span>
-        <div id="wrapper">
-        </div>
-    </body>
+<html id="adapt" class="no-js" lang="en" dir="ltr">
+  <head>
+    <script type="text/javascript">
+      window.ADAPT_BUILD_TYPE = '@@build.type';
+    </script>
+    <script src="libraries/js-cookie.js"></script>
+    <script src="libraries/xapiwrapper.min.js"></script>
+    <script src="offline_xapi_adl_wrapper.js"></script>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Adapt</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <script src="libraries/modernizr.js"></script>
+    <script src="adapt/js/scriptLoader.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <div id="wrapper">
+      </div>
+    </div>
+  </body>
 </html>

--- a/required/xapi_test_harness.html
+++ b/required/xapi_test_harness.html
@@ -3,29 +3,25 @@
   configuration for this extension for the Rustici method to be utilised
 -->
 
-<!--[if IE]><![endif]-->
 <!doctype html>
-<!--[if IE 7 ]><html id="adapt" class="ie ie7 no-js" lang="en"><![endif]-->
-<!--[if IE 8 ]><html id="adapt" class="ie ie8 no-js" lang="en"><![endif]-->
-<!--[if IE 9 ]><html id="adapt" class="ie ie9 no-js" lang="en"><![endif]-->
-<!--[if gt IE 9]><!--><html id="adapt" class="no-js" lang="en"><!--<![endif]-->
-    <head>
-        <script src="offline_xapi_adl_wrapper.js" type="text/javascript" language="javascript"></script>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-        <meta content="utf-8" http-equiv="encoding">
-        <meta name="apple-mobile-web-app-capable" content="yes"/>
-        <title></title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-        <link href="adapt/css/adapt.css" type="text/css" rel="stylesheet"/>
-        <script src="libraries/modernizr.js" type="text/javascript" language="javascript"></script>
-        <script src="adapt/js/scriptLoader.js" type="text/javascript" language="javascript"></script>
-    </head>
-
-    <body>
-        <button id="accessibility-toggle" class="base button a11y-ignore-focus" role="button" ></button>
-        <span id="accessibility-instructions" class="aria-label" role="region" tabindex="0"></span>
-        <div id="wrapper">
-        </div>
-    </body>
+<html id="adapt" class="no-js" lang="en" dir="ltr">
+  <head>
+    <script type="text/javascript">
+      window.ADAPT_BUILD_TYPE = '@@build.type';
+    </script>
+    <script src="offline_xapi_wrapper.js"></script>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Adapt</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <script src="libraries/modernizr.js"></script>
+    <script src="adapt/js/scriptLoader.js"></script>
+  </head>
+  <body>
+    <div id="app">
+      <div id="wrapper">
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-xapi/issues/122

### Fix
Updated the html markup for the test harness files.
- Removed legacy dom elements used for accessibility
- Links to `adapt.css` and not the non-existant `adapt/css/adapt.css`
- Removed references to IE11, yay

(Copy/pasted https://github.com/adaptlearning/adapt-contrib-core/blob/master/required/index.html then added back in the xapi test scripts)

### Testing
1. Build an adapt course with the adapt-contrib-xapi extension enabled
2. Serve the course `grunt server`
3. Load one of the test html files e.g. `https://localhost:9001/xapi_adl_test_harness.html`


