### PR TITLE
fix: Adding a pagehide listener to cover bases when unload becomes deprecated

### DIFF
--- a/js/XAPI.js
+++ b/js/XAPI.js
@@ -127,7 +127,7 @@ class XAPI extends Backbone.Model {
     if (['ios', 'android'].indexOf(Adapt.device.OS) > -1) {
       $(document).on('visibilitychange', this.onVisibilityChange.bind(this));
     } else {
-      $(window).on('beforeunload unload', this.sendUnloadStatements.bind(this));
+      $(window).on('beforeunload unload pagehide', this.sendUnloadStatements.bind(this));
     }
 
     if (!this.get('shouldTrackState')) {


### PR DESCRIPTION
Partly fixes [FW3481](https://github.com/adaptlearning/adapt_framework/issues/3481)

### Fix
* Added a 'pagehide' listener to backup the soon-to-be-deprecated 'unload' event